### PR TITLE
For discussion: wrap generated service and client in module.

### DIFF
--- a/protoc-gen-twirp_ruby/main.go
+++ b/protoc-gen-twirp_ruby/main.go
@@ -107,8 +107,10 @@ func (g *generator) generateRubyCode(file *descriptor.FileDescriptorProto, pbFil
 
 	for i, service := range file.Service {
 		svcName := service.GetName()
+		print(b, "%smodule %s", indent, camelCase(svcName))
+		indent += 1
 
-		print(b, "%sclass %sService < Twirp::Service", indent, camelCase(svcName))
+		print(b, "%sclass Service < Twirp::Service", indent)
 		if pkgName != "" {
 			print(b, "%s  package '%s'", indent, pkgName)
 		}
@@ -123,8 +125,11 @@ func (g *generator) generateRubyCode(file *descriptor.FileDescriptorProto, pbFil
 		print(b, "%send", indent)
 		print(b, "")
 
-		print(b, "%sclass %sClient < Twirp::Client", indent, camelCase(svcName))
-		print(b, "%s  client_for %sService", indent, camelCase(svcName))
+		print(b, "%sclass Client < Twirp::Client", indent)
+		print(b, "%s  client_for Service", indent)
+		print(b, "%send", indent)
+
+		indent -= 1
 		print(b, "%send", indent)
 		if i < len(file.Service)-1 {
 			print(b, "")


### PR DESCRIPTION
I'm looking to wrap the generated service and client in a module to better support projects that use Zeitwerk (i.e. rails). This will allow the zeitwerk to work with a simple custom [inflector](https://github.com/fxn/zeitwerk/blob/main/README.md#custom-inflector) like:

```ruby
class Inflector < Zeitwerk::Inflector
  def camelize(basename, abspath)
    if basename =~ /\A(.*)_twirp/
      super($1, abspath) + "Service"
    else
      super
    end
  end
end
```
It also brings the style in line with what grpc-tools generates.

For an example service the twirp file generated would be:

```ruby
# Code generated by protoc-gen-twirp_ruby 1.9.0, DO NOT EDIT.
require 'twirp'
require_relative 'tracer_pb.rb'

module TracerService
  class Service < Twirp::Service
    package 'tracer.v1'
    service 'TracerService'
    rpc :Bullet, BulletRequest, BulletResponse, :ruby_method => :bullet
  end

  class Client < Twirp::Client
    client_for Service
  end
end
```

This would obviously be a breaking change. 