### PR TITLE
Code generation should only append "Service" when necessary.

### DIFF
--- a/example/hello_world/service.proto
+++ b/example/hello_world/service.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package example.hello_world;
 
 
-service HelloWorld {
+service HelloWorldService {
     rpc Hello(HelloRequest) returns (HelloResponse);
 }
 

--- a/example/hello_world/service_twirp.rb
+++ b/example/hello_world/service_twirp.rb
@@ -6,11 +6,11 @@ module Example
   module HelloWorld
     class HelloWorldService < ::Twirp::Service
       package 'example.hello_world'
-      service 'HelloWorld'
+      service 'HelloWorldService'
       rpc :Hello, HelloRequest, HelloResponse, :ruby_method => :hello
     end
 
-    class HelloWorldClient < ::Twirp::Client
+    class HelloWorldServiceClient < ::Twirp::Client
       client_for HelloWorldService
     end
   end

--- a/example/hello_world/service_twirp.rb
+++ b/example/hello_world/service_twirp.rb
@@ -10,7 +10,7 @@ module Example
       rpc :Hello, HelloRequest, HelloResponse, :ruby_method => :hello
     end
 
-    class HelloWorldServiceClient < ::Twirp::Client
+    class HelloWorldClient < ::Twirp::Client
       client_for HelloWorldService
     end
   end

--- a/protoc-gen-twirp_ruby/main.go
+++ b/protoc-gen-twirp_ruby/main.go
@@ -109,7 +109,12 @@ func (g *generator) generateRubyCode(file *descriptor.FileDescriptorProto, pbFil
 	for i, service := range file.Service {
 		svcName := service.GetName()
 
-		print(b, "%sclass %sService < ::Twirp::Service", indent, camelCase(svcName))
+		// Well-named services already end in "Service"; fixup services that don't.
+		if !strings.HasSuffix(svcName, "Service") {
+			svcName += "Service"
+		}
+
+		print(b, "%sclass %s < ::Twirp::Service", indent, camelCase(svcName))
 		if pkgName != "" {
 			print(b, "%s  package '%s'", indent, pkgName)
 		}
@@ -125,7 +130,7 @@ func (g *generator) generateRubyCode(file *descriptor.FileDescriptorProto, pbFil
 		print(b, "")
 
 		print(b, "%sclass %sClient < ::Twirp::Client", indent, camelCase(svcName))
-		print(b, "%s  client_for %sService", indent, camelCase(svcName))
+		print(b, "%s  client_for %s", indent, camelCase(svcName))
 		print(b, "%send", indent)
 		if i < len(file.Service)-1 {
 			print(b, "")

--- a/protoc-gen-twirp_ruby/main.go
+++ b/protoc-gen-twirp_ruby/main.go
@@ -114,6 +114,9 @@ func (g *generator) generateRubyCode(file *descriptor.FileDescriptorProto, pbFil
 			svcName += "Service"
 		}
 
+		// The client name strips the "Service" suffix for better readability.
+		clientName := strings.TrimSuffix(svcName, "Service")
+
 		print(b, "%sclass %s < ::Twirp::Service", indent, camelCase(svcName))
 		if pkgName != "" {
 			print(b, "%s  package '%s'", indent, pkgName)
@@ -129,7 +132,7 @@ func (g *generator) generateRubyCode(file *descriptor.FileDescriptorProto, pbFil
 		print(b, "%send", indent)
 		print(b, "")
 
-		print(b, "%sclass %sClient < ::Twirp::Client", indent, camelCase(svcName))
+		print(b, "%sclass %sClient < ::Twirp::Client", indent, camelCase(clientName))
 		print(b, "%s  client_for %s", indent, camelCase(svcName))
 		print(b, "%send", indent)
 		if i < len(file.Service)-1 {

--- a/test/client_json_test.rb
+++ b/test/client_json_test.rb
@@ -16,12 +16,12 @@ class ClientJSONTest < Minitest::Test
   end
 
   def test_client_json_success
-    c = Twirp::ClientJSON.new(conn_stub("/my.pkg.Talking/Blah") {|req|
+    c = Twirp::ClientJSON.new(conn_stub("/my.pkg.TalkingService/Blah") {|req|
       assert_equal "application/json", req.request_headers['Content-Type']
       assert_equal '{"blah1":1,"blah2":2}', req.body # body is json
 
       [200, {}, '{"blah_resp": 3}']
-    }, package: "my.pkg", service: "Talking")
+    }, package: "my.pkg", service: "TalkingService")
 
     resp = c.rpc :Blah, blah1: 1, blah2: 2
     assert_nil resp.error
@@ -30,12 +30,12 @@ class ClientJSONTest < Minitest::Test
   end
 
   def test_client_json_thennable
-    c = Twirp::ClientJSON.new(conn_stub_thennable("/my.pkg.Talking/Blah") {|req|
+    c = Twirp::ClientJSON.new(conn_stub_thennable("/my.pkg.TalkingService/Blah") {|req|
       assert_equal "application/json", req.request_headers['Content-Type']
       assert_equal '{"blah1":1,"blah2":2}', req.body # body is json
 
       [200, {}, '{"blah_resp": 3}']
-    }, package: "my.pkg", service: "Talking")
+    }, package: "my.pkg", service: "TalkingService")
 
     resp_thennable = c.rpc :Blah, blah1: 1, blah2: 2
     # the final `.then {}` call will yield a ClientResp
@@ -54,12 +54,12 @@ class ClientJSONTest < Minitest::Test
   end
 
   def test_client_json_strict_encoding
-    c = Twirp::ClientJSON.new(conn_stub("/my.pkg.Talking/Blah") {|req|
+    c = Twirp::ClientJSON.new(conn_stub("/my.pkg.TalkingService/Blah") {|req|
       assert_equal "application/json; strict=true", req.request_headers['Content-Type']
       assert_equal '{"blah1":1,"blah2":2}', req.body # body is json
 
       [200, {}, '{"blah_resp": 3}']
-    }, package: "my.pkg", service: "Talking", strict: true)
+    }, package: "my.pkg", service: "TalkingService", strict: true)
 
     resp = c.rpc :Blah, blah1: 1, blah2: 2
     assert_nil resp.error

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -9,21 +9,21 @@ require_relative './fake_services'
 class ClientTest < Minitest::Test
 
   def test_new_empty_client
-    c = EmptyClient.new("http://localhost:8080")
+    c = EmptyServiceClient.new("http://localhost:8080")
     refute_nil c
     refute_nil c.instance_variable_get(:@conn) # make sure that connection was assigned
-    assert_equal "EmptyClient", c.instance_variable_get(:@service_full_name)
+    assert_equal "EmptyService", c.instance_variable_get(:@service_full_name)
   end
 
   def test_new_with_invalid_url
     assert_raises URI::InvalidURIError do
-      EmptyClient.new("invalid uri with unescaped spaces")
+      EmptyServiceClient.new("invalid uri with unescaped spaces")
     end
   end
 
   def test_new_with_invalid_faraday_connection
     assert_raises ArgumentError do
-      EmptyClient.new(something: "else")
+      EmptyServiceClient.new(something: "else")
     end
   end
 
@@ -31,13 +31,13 @@ class ClientTest < Minitest::Test
     # To avoid collisions, the Twirp::Client class should only have the rpc method.
     assert_equal [:rpc], Twirp::Client.instance_methods(false)
 
-    # If one of the methods is being implemented through the DSL, the colision should be avoided, keeping the previous method.
-    num_mthds = EmptyClient.instance_methods.size
-    EmptyClient.rpc :Rpc, Example::Empty, Example::Empty, :ruby_method => :rpc
-    assert_equal num_mthds, EmptyClient.instance_methods.size # no new method was added (is a collision)
+    # If one of the methods is being implemented through the DSL, the collision should be avoided, keeping the previous method.
+    num_mthds = EmptyServiceClient.instance_methods.size
+    EmptyServiceClient.rpc :Rpc, Example::Empty, Example::Empty, :ruby_method => :rpc
+    assert_equal num_mthds, EmptyServiceClient.instance_methods.size # no new method was added (is a collision)
 
     # Make sure that the previous .rpc method was not modified
-    c = EmptyClient.new(conn_stub("/EmptyClient/Rpc") {|req|
+    c = EmptyServiceClient.new(conn_stub("/EmptyService/Rpc") {|req|
       [200, protoheader, proto(Example::Empty, {})]
     })
     resp = c.rpc(:Rpc, {})
@@ -45,17 +45,17 @@ class ClientTest < Minitest::Test
     refute_nil resp.data
 
     # Adding a method that would override super-class methods like .to_s should also be avoided.
-    EmptyClient.rpc :ToString, Example::Empty, Example::Empty, :ruby_method => :to_s
-    assert_equal num_mthds, EmptyClient.instance_methods.size # no new method was added (is a collision)
+    EmptyServiceClient.rpc :ToString, Example::Empty, Example::Empty, :ruby_method => :to_s
+    assert_equal num_mthds, EmptyServiceClient.instance_methods.size # no new method was added (is a collision)
 
     # Make sure that the previous .to_s method was not modified
-    c = EmptyClient.new("http://localhost:8080")
+    c = EmptyServiceClient.new("http://localhost:8080")
     resp = c.to_s
     assert_equal String, resp.class
 
     # Adding any other rpc would work as expected
-    EmptyClient.rpc :Other, Example::Empty, Example::Empty, :ruby_method => :other
-    assert_equal num_mthds + 1, EmptyClient.instance_methods.size # new method added
+    EmptyServiceClient.rpc :Other, Example::Empty, Example::Empty, :ruby_method => :other
+    assert_equal num_mthds + 1, EmptyServiceClient.instance_methods.size # new method added
   end
 
 
@@ -63,7 +63,7 @@ class ClientTest < Minitest::Test
   # ----------------------------
 
   def test_proto_success
-    c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub("/example.HaberdasherService/MakeHat") {|req|
       [200, protoheader, proto(Example::Hat, inches: 99, color: "red")]
     })
     resp = c.make_hat({})
@@ -73,7 +73,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_proto_thennable
-    c = Example::HaberdasherClient.new(conn_stub_thennable("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub_thennable("/example.HaberdasherService/MakeHat") {|req|
       [200, protoheader, proto(Example::Hat, inches: 99, color: "red")]
     })
     resp_thennable = c.make_hat({})
@@ -94,7 +94,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_proto_send_headers
-    c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub("/example.HaberdasherService/MakeHat") {|req|
       assert_equal "Bar", req.request_headers['My-Foo-Header']
       [200, protoheader, proto(Example::Hat, inches: 99, color: "red")]
     })
@@ -105,7 +105,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_proto_serialized_request_body_attrs
-    c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub("/example.HaberdasherService/MakeHat") {|req|
       size = Example::Size.decode(req.body) # body is valid protobuf
       assert_equal 666, size.inches
 
@@ -117,7 +117,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_proto_serialized_request_body
-    c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub("/example.HaberdasherService/MakeHat") {|req|
       assert_equal "application/protobuf", req.request_headers['Content-Type']
 
       size = Example::Size.decode(req.body) # body is valid protobuf
@@ -131,7 +131,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_proto_twirp_error
-    c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub("/example.HaberdasherService/MakeHat") {|req|
       [500, {}, json(code: "internal", msg: "something went wrong")]
     })
     resp = c.make_hat(inches: 1)
@@ -142,7 +142,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_proto_intermediary_plain_error
-    c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub("/example.HaberdasherService/MakeHat") {|req|
       [503, {}, 'plain text error from proxy']
     })
     resp = c.make_hat(inches: 1)
@@ -156,7 +156,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_proto_redirect_error
-    c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub("/example.HaberdasherService/MakeHat") {|req|
       [300, {'location' => "http://rainbow.com"}, '']
     })
     resp = c.make_hat(inches: 1)
@@ -169,7 +169,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_proto_missing_response_header
-    c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub("/example.HaberdasherService/MakeHat") {|req|
       [200, {}, proto(Example::Hat, inches: 99, color: "red")]
     })
     resp = c.make_hat({})
@@ -179,7 +179,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_error_with_invalid_code
-    c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub("/example.HaberdasherService/MakeHat") {|req|
       [500, {}, json(code: "unicorn", msg: "the unicorn is here")]
     })
     resp = c.make_hat({})
@@ -190,7 +190,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_error_with_no_code
-    c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub("/example.HaberdasherService/MakeHat") {|req|
       [500, {}, json(msg: "I have no code of honor")]
     })
     resp = c.make_hat({})
@@ -207,7 +207,7 @@ class ClientTest < Minitest::Test
   # ------------------------
 
   def test_json_success
-    c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub("/example.HaberdasherService/MakeHat") {|req|
       [200, jsonheader, '{"inches": 99, "color": "red"}']
     }, content_type: "application/json")
 
@@ -218,7 +218,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_json_thennable
-    c = Example::HaberdasherClient.new(conn_stub_thennable("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub_thennable("/example.HaberdasherService/MakeHat") {|req|
       [200, jsonheader, '{"inches": 99, "color": "red"}']
     }, content_type: "application/json")
 
@@ -239,7 +239,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_json_send_headers
-    c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub("/example.HaberdasherService/MakeHat") {|req|
       assert_equal "Bar", req.request_headers['My-Foo-Header']
       [200, jsonheader, '{"inches": 99, "color": "red"}']
     }, content_type: "application/json")
@@ -250,7 +250,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_json_serialized_request_body_attrs
-    c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub("/example.HaberdasherService/MakeHat") {|req|
       assert_equal "application/json", req.request_headers['Content-Type']
       assert_equal '{"inches":666}', req.body # body is valid json
       [200, jsonheader, '{}']
@@ -262,7 +262,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_json_serialized_request_body_object
-    c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub("/example.HaberdasherService/MakeHat") {|req|
       assert_equal "application/json", req.request_headers['Content-Type']
       assert_equal '{"inches":666}', req.body # body is valid json
       [200, jsonheader, '{}']
@@ -274,7 +274,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_json_error
-    c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub("/example.HaberdasherService/MakeHat") {|req|
       [500, {}, json(code: "internal", msg: "something went wrong")]
     }, content_type: "application/json")
 
@@ -286,7 +286,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_json_missing_response_header
-    c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+    c = Example::HaberdasherServiceClient.new(conn_stub("/example.HaberdasherService/MakeHat") {|req|
       [200, {}, json(inches: 99, color: "red")]
     }, content_type: "application/json")
 
@@ -301,7 +301,7 @@ class ClientTest < Minitest::Test
   # ------------------
 
   def test_rpc_success
-    c = FooClient.new(conn_stub("/Foo/Foo") {|req|
+    c = FooServiceClient.new(conn_stub("/FooService/Foo") {|req|
       [200, protoheader, proto(Foo, foo: "out")]
     })
     resp = c.rpc :Foo, foo: "in"
@@ -311,7 +311,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_rpc_send_headers
-    c = FooClient.new(conn_stub("/Foo/Foo") {|req|
+    c = FooServiceClient.new(conn_stub("/FooService/Foo") {|req|
       assert_equal "Bar", req.request_headers['My-Foo-Header']
       [200, protoheader, proto(Foo, foo: "out")]
     })
@@ -322,7 +322,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_rpc_error
-    c = FooClient.new(conn_stub("/Foo/Foo") {|req|
+    c = FooServiceClient.new(conn_stub("/FooService/Foo") {|req|
       [400, {}, json(code: "invalid_argument", msg: "dont like empty")]
     })
     resp = c.rpc :Foo, foo: ""
@@ -333,7 +333,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_rpc_serialization_exception
-    c = FooClient.new(conn_stub("/Foo/Foo") {|req|
+    c = FooServiceClient.new(conn_stub("/FooService/Foo") {|req|
       [200, protoheader, "badstuff"]
     })
     assert_raises Google::Protobuf::ParseError do
@@ -342,7 +342,7 @@ class ClientTest < Minitest::Test
   end
 
   def test_rpc_invalid_method
-    c = FooClient.new("http://localhost")
+    c = FooServiceClient.new("http://localhost")
     resp = c.rpc :OtherStuff, foo: "noo"
     assert_nil resp.data
     refute_nil resp.error

--- a/test/fake_services.rb
+++ b/test/fake_services.rb
@@ -26,14 +26,14 @@ end
 # Twirp Service.
 # An example of the result of the protoc twirp_ruby plugin code generator.
 module Example
-  class Haberdasher < Twirp::Service
+  class HaberdasherService < Twirp::Service
     package "example"
-    service "Haberdasher"
+    service "HaberdasherService"
     rpc :MakeHat, Size, Hat, :ruby_method => :make_hat
   end
 
-  class HaberdasherClient < Twirp::Client
-    client_for Haberdasher
+  class HaberdasherServiceClient < Twirp::Client
+    client_for HaberdasherService
   end
 end
 
@@ -52,7 +52,8 @@ end
 # Twirp Service with no package and no rpc methods.
 class EmptyService < Twirp::Service
 end
-class EmptyClient < Twirp::Client
+class EmptyServiceClient < Twirp::Client
+  client_for EmptyService
 end
 
 # Foo message
@@ -63,8 +64,8 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
 end
 Foo = Google::Protobuf::DescriptorPool.generated_pool.lookup("Foo").msgclass
 
-# Foo Client
-class FooClient < Twirp::Client
-  service "Foo"
+# Foo Service Client
+class FooServiceClient < Twirp::Client
+  service "FooService"
   rpc :Foo, Foo, Foo, :ruby_method => :foo
 end

--- a/test/fake_services.rb
+++ b/test/fake_services.rb
@@ -32,7 +32,7 @@ module Example
     rpc :MakeHat, Size, Hat, :ruby_method => :make_hat
   end
 
-  class HaberdasherServiceClient < Twirp::Client
+  class HaberdasherClient < Twirp::Client
     client_for HaberdasherService
   end
 end
@@ -52,7 +52,7 @@ end
 # Twirp Service with no package and no rpc methods.
 class EmptyService < Twirp::Service
 end
-class EmptyServiceClient < Twirp::Client
+class EmptyClient < Twirp::Client
   client_for EmptyService
 end
 
@@ -65,7 +65,7 @@ end
 Foo = Google::Protobuf::DescriptorPool.generated_pool.lookup("Foo").msgclass
 
 # Foo Service Client
-class FooServiceClient < Twirp::Client
+class FooClient < Twirp::Client
   service "FooService"
   rpc :Foo, Foo, Foo, :ruby_method => :foo
 end


### PR DESCRIPTION
Protobuf services should end in `Service`. This is a [buf lint rule](https://github.com/bufbuild/buf-examples/blob/main/linting/bad/acme/weather/v1/weather.proto#L39), recommended via [the protobuf style guide](https://developers.google.com/protocol-buffers/docs/style#services) as linked to via [Twirp Best Practices](https://twitchtv.github.io/twirp/docs/best_practices.html))

Therefore, we only append "Service" to fixup services that are not well named. This avoids generating e.g. "MessagesServiceService".

This change updates the generator library itself, and will require a new release. Since the release changes the name of the generated services in some cases, it should be flagged as a breaking change.

Testing this was a bit of a challenge for me as I've never written go before. Here are the steps I took:

First, build and install the updated generator code.

```
# Working directory is my forked repository, with my service-suffix-handling branch checked out
cd ./protoc-gen-twirp_ruby 
go build   
go install
```

Then, I updated the example service definition in commit e1cdd74e to follow Potobuf style guides.

Finally, I ran my built code-gen:

```
cd ../example    
protoc --proto_path=. ./hello_world/service.proto --ruby_out=. --twirp_ruby_out=.
```

For consistency, I manually updated the Ruby specs in commit 8125bf0 such that the fake services follow the "service ends in Service" naming convention.