### PR TITLE
Update generated service and client class names to better handle well-named services.

### DIFF
--- a/protoc-gen-twirp_ruby/main.go
+++ b/protoc-gen-twirp_ruby/main.go
@@ -109,7 +109,14 @@ func (g *generator) generateRubyCode(file *descriptor.FileDescriptorProto, pbFil
 	for i, service := range file.Service {
 		svcName := service.GetName()
 
-		print(b, "%sclass %sService < ::Twirp::Service", indent, camelCase(svcName))
+		// The generated service class name should end in "Service"; Only append the
+		// suffix if the service is not already well-named.
+		svcClassName := svcName
+		if !strings.HasSuffix(svcClassName, "Service") {
+			svcClassName += "Service"
+		}
+
+		print(b, "%sclass %s < ::Twirp::Service", indent, camelCase(svcClassName))
 		if pkgName != "" {
 			print(b, "%s  package '%s'", indent, pkgName)
 		}
@@ -125,7 +132,7 @@ func (g *generator) generateRubyCode(file *descriptor.FileDescriptorProto, pbFil
 		print(b, "")
 
 		print(b, "%sclass %sClient < ::Twirp::Client", indent, camelCase(svcName))
-		print(b, "%s  client_for %sService", indent, camelCase(svcName))
+		print(b, "%s  client_for %s", indent, camelCase(svcClassName))
 		print(b, "%send", indent)
 		if i < len(file.Service)-1 {
 			print(b, "")

--- a/protoc-gen-twirp_ruby/main.go
+++ b/protoc-gen-twirp_ruby/main.go
@@ -131,7 +131,10 @@ func (g *generator) generateRubyCode(file *descriptor.FileDescriptorProto, pbFil
 		print(b, "%send", indent)
 		print(b, "")
 
-		print(b, "%sclass %sClient < ::Twirp::Client", indent, camelCase(svcName))
+		// Strip the "Service" suffix if present for better readability.
+		clientClassName := strings.TrimSuffix(svcName, "Service") + "Client"
+
+		print(b, "%sclass %s < ::Twirp::Client", indent, camelCase(clientClassName))
 		print(b, "%s  client_for %s", indent, camelCase(svcClassName))
 		print(b, "%send", indent)
 		if i < len(file.Service)-1 {


### PR DESCRIPTION
This PR follows #91 and subsequent discussions.

When a service is well-named and ends in "Service", such as "MessagesService", the generator generates `class MessagesServiceService < Twirp::Serivice` and `class MessagesServiceClient < Twirp::Client`.

This change causes the generator to generate `class MessagesService < Twirp::Serivice` and `class MessagesClient < Twirp::Client` instead.

The service name passed to the `service` DSL is not impacted (which was the problem in #91 that needed a revert).

For backwards compatibility, this change _does not_ impact the current [hello_world example](./example/hello_world), as demonstrated by:

```bash
# Check out and build the generator using updates from the this branch
$ git checkout service-class-name-suffix-fix
$ cd ./protoc-gen-twirp_ruby 
$ go build
$ go install

# Run code gen
$ cd ../example 
$ protoc --proto_path=. ./hello_world/service.proto --ruby_out=. --twirp_ruby_out=.

# Demonstrate no changes for services not already well-named
$ git status
On branch service-class-name-suffix-fix
Your branch is up to date with 'origin/service-class-name-suffix-fix'.

nothing to commit, working tree clean
```

I'm not familiar enough with go and testing to write tests for this in `main_test.go`. Any help there is appreciated.